### PR TITLE
Ability to have IIS App Pools use special builtin accounts

### DIFF
--- a/src/ConDep.Dsl.Operations/Remote/PSScripts/Iis.ps1
+++ b/src/ConDep.Dsl.Operations/Remote/PSScripts/Iis.ps1
@@ -179,9 +179,21 @@ function New-ConDepAppPool {
 	if($AppPoolOptions) {
 		if($AppPoolOptions.Enable32Bit) { $newAppPool.enable32BitAppOnWin64 = $AppPoolOptions.Enable32Bit }
 		if($AppPoolOptions.IdentityUsername) { 
-			$newAppPool.processModel.identityType = 'SpecificUser'
-			$newAppPool.processModel.username = $AppPoolOptions.IdentityUsername
-			$newAppPool.processModel.password = $AppPoolOptions.IdentityPassword
+			if($AppPoolOptions.IdentityUsername -eq 'NetworkService') {
+				$newAppPool.processModel.identityType = 'NetworkService'
+			}
+			elseif($AppPoolOptions.IdentityUsername -eq 'LocalService') {
+				$newAppPool.processModel.identityType = 'LocalService'
+			}
+			elseif($AppPoolOptions.IdentityUsername -eq 'LocalSystem') {
+				$newAppPool.processModel.identityType = 'LocalSystem'
+			}
+			else
+			{
+				$newAppPool.processModel.identityType = 'SpecificUser'
+				$newAppPool.processModel.username = $AppPoolOptions.IdentityUsername
+				$newAppPool.processModel.password = $AppPoolOptions.IdentityPassword
+			}
 		}
 		
 		if($AppPoolOptions.IdleTimeoutInMinutes) { $newAppPool.processModel.idleTimeout = [TimeSpan]::FromMinutes($AppPoolOptions.IdleTimeoutInMinutes) }


### PR DESCRIPTION
Added ability to set IIS app pool identity model as NetworkService, LocalService, LocalSystem via "magic strings" passed in as IdentityUsername

I needed to set up a deploy as a NetworkService, but while the docs implied I could send in NetworkService to get this behavior, it was actually setting a SpecificUser with that name.  

Tested on my deploy, and it now works as expected. 

PS: Can't imagine anyone would be trying to use a built in account with the same name, but they can specify ".\NetworkService" if they really want to
