### PR TITLE
Add support for TLS 1.2 with https

### DIFF
--- a/src/ConDep.Dsl.Operations/Remote/PSScripts/Msi.ps1
+++ b/src/ConDep.Dsl.Operations/Remote/PSScripts/Msi.ps1
@@ -1,5 +1,6 @@
 ﻿function Install-ConDepMsiFromUri($uri, $tempFilePath) {
     $tempFilePath = $ExecutionContext.InvokeCommand.ExpandString($tempFilePath)
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 	write-Host "Downloading Msi from $uri"
 	(New-Object System.Net.WebClient).DownloadFile($uri,$tempFilePath) 
 	write-Host "Download finished"
@@ -32,6 +33,7 @@ function Install-ConDepExecutableFromFile($path, $params) {
 
 function Get-ConDepRemoteFile($uri, $tempFilePath) {
     $tempFilePath = $ExecutionContext.InvokeCommand.ExpandString($tempFilePath)
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 	write-Host "Downloading executable from $uri"
 	(New-Object System.Net.WebClient).DownloadFile($uri,$tempFilePath)
 	write-Host "Download finished"


### PR DESCRIPTION
Older powershell versions does not have TLS 1.2 enabled as default.